### PR TITLE
Fix changelog link in readme, date release in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project from 2019-01-21 will be documented in this f
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.0.0] - 2019-01-22
 ### Added
 - Added documentation to the interface.
 - Added the `completionBlock` property for executing work upon completion of the animation.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Uses [Airbnb Lottie](https://github.com/airbnb/lottie-android) for Android and [
 
 ## Changelog
 
-All notable changes to this project will be documented in the [changelog](changelog.md).
+All notable changes to this project will be documented in the [changelog](CHANGELOG.md).
 
 ## Demo Screen
 


### PR DESCRIPTION
Fixed the changelog link in the readme, as it's case sensitive.
Dated the 3.0.0 release in the changelog.

I should've been more clued up the first time, my apologies. Thanks for handling the merges and releases!

@bradmartin 