### PR TITLE
fix(ios): replace json extension in last effort to find resource

### DIFF
--- a/src/lottie.ios.ts
+++ b/src/lottie.ios.ts
@@ -60,7 +60,7 @@ export class LottieView extends LottieViewBase {
       // make one last effort to just find the file in app_resources without checking the prefix in case the user forgot to pass it
       try {
         this.nativeView.compatibleAnimation = CompatibleAnimation.alloc().initWithNameBundle(
-          src,
+          src.replace('.json', ''),
           NSBundle.mainBundle
         );
       } catch (error) {


### PR DESCRIPTION
We have always passed our lottie animations as the file name + extension, and this plugin has handled it. We updated to the latest and it no longer worked after the rewrite and integration of the new Lottie pod.

Replacing the `.json` will stay consistent with the case where the RESOURCE_PREFIX was provided, where it also uses the same native method `initWithNameBundle`.
